### PR TITLE
fix: bind public inputs to Fiat-Shamir transcript

### DIFF
--- a/src/prover.rs
+++ b/src/prover.rs
@@ -24,14 +24,18 @@ where
     PF<EF>: PrimeField64,
 {
     #[must_use]
-    pub fn new(permutation: P) -> Self {
+    pub fn new(permutation: P, public_inputs: &[PF<EF>]) -> Self {
         assert!(EF::DIMENSION <= RATE);
-        Self {
+        let mut state = Self {
             challenger: DuplexChallenger::new(permutation),
             transcript: Vec::new(),
             n_zeros: 0,
             _extension_field: std::marker::PhantomData,
+        };
+        if !public_inputs.is_empty() {
+            state.add_base_scalars(public_inputs);
         }
+        state
     }
 
     pub fn proof_size_fe(&self) -> usize {

--- a/tests/grinding.rs
+++ b/tests/grinding.rs
@@ -12,7 +12,7 @@ type EF = QuinticExtensionFieldKB;
 fn bench_grinding() {
     let n_reps = 100;
     for grinding_bits in [5, 10, 15, 20] {
-        let mut prover_state = ProverState::<EF, _>::new(get_poseidon16());
+        let mut prover_state = ProverState::<EF, _>::new(get_poseidon16(), &[]);
         let time = Instant::now();
         for _ in 0..n_reps {
             prover_state.pow_grinding(grinding_bits);


### PR DESCRIPTION
## Summary

**Severity: HIGH (F-03)**

`ProverState::new()` in `src/prover.rs:27-35` creates a fresh DuplexChallenger without absorbing any public inputs into the sponge state. This means the Fiat-Shamir transcript is not bound to the statement being proved.

An adversary can exploit this by reusing a valid proof for statement S1 as a "proof" for a different statement S2, since the challenge derivation is identical when the same witness structure is used. This breaks the soundness of any protocol built on top of this Fiat-Shamir implementation.

## Fix

Modify `ProverState::new()` to accept a `public_inputs: &[PF<EF>]` parameter and absorb it into the challenger via `add_base_scalars()` before any proof generation begins:

```rust
pub fn new(permutation: P, public_inputs: &[PF<EF>]) -> Self {
    // ...
    if !public_inputs.is_empty() {
        state.add_base_scalars(public_inputs);
    }
    state
}
```

**BREAKING CHANGE**: `ProverState::new()` now requires a second argument. Callers with no public inputs can pass `&[]` to preserve the previous behavior. The test in `tests/grinding.rs` has been updated accordingly.

## Test plan

- [ ] Verify existing tests pass with `&[]` for no public inputs
- [ ] Verify that two ProverStates initialized with different public inputs produce different challenges
- [ ] Verify that two ProverStates initialized with the same public inputs produce the same challenges
- [ ] Update downstream callers (e.g., `leanMultisig/crates/utils/src/wrappers.rs`, `leanMultisig/crates/whir/tests/run_whir.rs`) to pass appropriate public inputs

Found during security audit of leanEthereum repositories.